### PR TITLE
Add `req_url` field to all logs

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,7 +91,7 @@ module.exports = function (options, logger) {
 
     var prefs = {}
     prefs[logName] = id
-    prefs.req_url = req.protocol + '://' + req.get('host') + req.originalUrl
+    prefs.req_path = req.path
     req.log = res.log = logger.child(prefs, true)
 
     req[propertyName] = res[propertyName] = id

--- a/index.js
+++ b/index.js
@@ -91,6 +91,7 @@ module.exports = function (options, logger) {
 
     var prefs = {}
     prefs[logName] = id
+    prefs.req_url = req.protocol + '://' + req.get('host') + req.originalUrl
     req.log = res.log = logger.child(prefs, true)
 
     req[propertyName] = res[propertyName] = id


### PR DESCRIPTION
This will log `req_url` every time `req.log` is used.

The catch is: every query parameter will also be logged. Should we filter out these? What if there are secrets in the url?